### PR TITLE
refactor(document): consolidate document management

### DIFF
--- a/construction_management/__manifest__.py
+++ b/construction_management/__manifest__.py
@@ -9,13 +9,10 @@
     'depends': [
         'project',
         'hr_timesheet',
-#        'planning',
-#        'documents',
         'purchase',
         'account',
         'stock',
         'hr',
-#        'quality_control',
         'maintenance',
     ],
     'data': [
@@ -26,6 +23,8 @@
         'views/procurement_and_inventory_views.xml',
         'views/site_and_field_views.xml',
         'views/workforce_and_timesheet_views.xml',
+        'views/planning_views.xml',
+        'views/quality_control_views.xml',
     ],
     'installable': True,
     'application': True,

--- a/construction_management/models/__init__.py
+++ b/construction_management/models/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from . import project
-#from . import document_management
+from . import document_management
 from . import budget_and_cost
 from . import procurement_and_inventory
 from . import site_and_field
 from . import workforce_and_timesheet
 from . import subcontractor_management
+from . import planning
+from . import quality_control

--- a/construction_management/models/budget_and_cost.py
+++ b/construction_management/models/budget_and_cost.py
@@ -12,12 +12,6 @@ class Project(models.Model):
 
     actual_vs_forecast = fields.Float(string='Actual vs. Forecast', compute='_compute_actual_vs_forecast')
 
-class CostSheet(models.Model):
-    _inherit = 'construction.cost.sheet'
-
-    subcontractor_costs = fields.Float(string='Subcontractor Costs')
-    material_costs = fields.Float(string='Material Costs')
-    labor_costs = fields.Float(string='Labor Costs')
 
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'

--- a/construction_management/models/document_management.py
+++ b/construction_management/models/document_management.py
@@ -2,16 +2,14 @@
 
 from odoo import models, fields, api
 
-class Document(models.Model):
-    _inherit = 'documents.document'
-
-    project_id = fields.Many2one('project.project', string='Project')
-
-class Drawing(models.Model):
-    _name = 'construction.drawing'
-    _description = 'Construction Drawing'
+class ConstructionDocument(models.Model):
+    _name = 'construction.document'
+    _description = 'Construction Document'
 
     name = fields.Char(string='Name', required=True)
     project_id = fields.Many2one('project.project', string='Project', required=True)
     attachment = fields.Binary(string='Attachment', required=True)
     version = fields.Char(string='Version')
+    description = fields.Text(string='Description')
+    date_uploaded = fields.Date(string='Date Uploaded', default=fields.Date.context_today)
+    uploaded_by = fields.Many2one('res.users', string='Uploaded By', default=lambda self: self.env.user)

--- a/construction_management/models/planning.py
+++ b/construction_management/models/planning.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+class ConstructionPlanning(models.Model):
+    _name = 'construction.planning'
+    _description = 'Construction Planning'
+
+    name = fields.Char(string='Name', required=True)
+    project_id = fields.Many2one('project.project', string='Project', required=True)
+    start_date = fields.Date(string='Start Date')
+    end_date = fields.Date(string='End Date')
+    duration = fields.Float(string='Duration', compute='_compute_duration', store=True)
+    task_ids = fields.One2many('project.task', 'planning_id', string='Tasks')
+
+    @api.depends('start_date', 'end_date')
+    def _compute_duration(self):
+        for record in self:
+            if record.start_date and record.end_date:
+                record.duration = (record.end_date - record.start_date).days
+            else:
+                record.duration = 0.0

--- a/construction_management/models/project.py
+++ b/construction_management/models/project.py
@@ -9,12 +9,17 @@ class Project(models.Model):
     critical_path = fields.Char(string='Critical Path')
     cost_sheet = fields.One2many('construction.cost.sheet', 'project_id', string='Cost Sheet')
     milestone_ids = fields.One2many('construction.milestone', 'project_id', string='Milestones')
+    purchase_order_ids = fields.One2many('purchase.order', 'project_id', string='Purchase Orders')
+    planning_ids = fields.One2many('construction.planning', 'project_id', string='Planning')
+    document_ids = fields.One2many('construction.document', 'project_id', string='Documents')
+    quality_control_ids = fields.One2many('construction.quality.control', 'project_id', string='Quality Control')
 
 class Task(models.Model):
     _inherit = 'project.task'
 
     # Add fields for construction management
     task_location = fields.Char(string='Task Location')
+    planning_id = fields.Many2one('construction.planning', string='Planning')
 
 class Milestone(models.Model):
     _name = 'construction.milestone'
@@ -34,6 +39,9 @@ class CostSheet(models.Model):
     project_id = fields.Many2one('project.project', string='Project', required=True)
     budget = fields.Float(string='Budget')
     actual_cost = fields.Float(string='Actual Cost', compute='_compute_actual_cost', store=True)
+    subcontractor_costs = fields.Float(string='Subcontractor Costs')
+    material_costs = fields.Float(string='Material Costs')
+    labor_costs = fields.Float(string='Labor Costs')
 
     @api.depends('project_id.timesheet_ids', 'project_id.purchase_order_ids')
     def _compute_actual_cost(self):

--- a/construction_management/models/quality_control.py
+++ b/construction_management/models/quality_control.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+class ConstructionQualityControl(models.Model):
+    _name = 'construction.quality.control'
+    _description = 'Construction Quality Control'
+
+    name = fields.Char(string='Name', required=True)
+    project_id = fields.Many2one('project.project', string='Project', required=True)
+    task_id = fields.Many2one('project.task', string='Task')
+    inspection_date = fields.Date(string='Inspection Date', default=fields.Date.context_today)
+    inspected_by = fields.Many2one('res.users', string='Inspected By', default=lambda self: self.env.user)
+    status = fields.Selection([
+        ('pass', 'Pass'),
+        ('fail', 'Fail'),
+    ], string='Status', default='fail')
+    notes = fields.Text(string='Notes')

--- a/construction_management/views/document_management_views.xml
+++ b/construction_management/views/document_management_views.xml
@@ -1,59 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <!-- Inherit the document form view to add new fields -->
-        <record id="view_document_form_inherited" model="ir.ui.view">
-            <field name="name">documents.document.form.inherited</field>
-            <field name="model">documents.document</field>
-            <field name="inherit_id" ref="documents.document_view_form"/>
+        <!-- Document views -->
+        <record id="view_construction_document_tree" model="ir.ui.view">
+            <field name="name">construction.document.tree</field>
+            <field name="model">construction.document</field>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='folder_id']" position="after">
-                    <field name="project_id"/>
-                </xpath>
-            </field>
-        </record>
-
-        <!-- Drawing views -->
-        <record id="view_construction_drawing_tree" model="ir.ui.view">
-            <field name="name">construction.drawing.tree</field>
-            <field name="model">construction.drawing</field>
-            <field name="arch" type="xml">
-                <tree string="Drawings">
+                <tree string="Documents">
                     <field name="name"/>
                     <field name="project_id"/>
                     <field name="version"/>
+                    <field name="date_uploaded"/>
+                    <field name="uploaded_by"/>
                 </tree>
             </field>
         </record>
 
-        <record id="view_construction_drawing_form" model="ir.ui.view">
-            <field name="name">construction.drawing.form</field>
-            <field name="model">construction.drawing</field>
+        <record id="view_construction_document_form" model="ir.ui.view">
+            <field name="name">construction.document.form</field>
+            <field name="model">construction.document</field>
             <field name="arch" type="xml">
-                <form string="Drawing">
+                <form string="Document">
                     <sheet>
                         <group>
                             <field name="name"/>
                             <field name="project_id"/>
                             <field name="version"/>
+                            <field name="date_uploaded"/>
+                            <field name="uploaded_by"/>
                             <field name="attachment" widget="binary" filename="name"/>
                         </group>
+                        <notebook>
+                            <page string="Description">
+                                <field name="description"/>
+                            </page>
+                        </notebook>
                     </sheet>
                 </form>
             </field>
         </record>
 
-        <record id="action_construction_drawing" model="ir.actions.act_window">
-            <field name="name">Drawings</field>
-            <field name="res_model">construction.drawing</field>
+        <record id="action_construction_document" model="ir.actions.act_window">
+            <field name="name">Documents</field>
+            <field name="res_model">construction.document</field>
             <field name="view_mode">tree,form</field>
         </record>
 
-        <menuitem id="menu_construction_drawing"
-            name="Drawings"
+        <menuitem id="menu_construction_document"
+            name="Documents"
             parent="project.menu_main_pm"
-            action="action_construction_drawing"
-            sequence="10"/>
+            action="action_construction_document"
+            sequence="50"/>
 
     </data>
 </odoo>

--- a/construction_management/views/planning_views.xml
+++ b/construction_management/views/planning_views.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Planning views -->
+        <record id="view_construction_planning_tree" model="ir.ui.view">
+            <field name="name">construction.planning.tree</field>
+            <field name="model">construction.planning</field>
+            <field name="arch" type="xml">
+                <tree string="Planning">
+                    <field name="name"/>
+                    <field name="project_id"/>
+                    <field name="start_date"/>
+                    <field name="end_date"/>
+                    <field name="duration"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_construction_planning_form" model="ir.ui.view">
+            <field name="name">construction.planning.form</field>
+            <field name="model">construction.planning</field>
+            <field name="arch" type="xml">
+                <form string="Planning">
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="project_id"/>
+                            <field name="start_date"/>
+                            <field name="end_date"/>
+                            <field name="duration"/>
+                        </group>
+                        <notebook>
+                            <page string="Tasks">
+                                <field name="task_ids"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_construction_planning" model="ir.actions.act_window">
+            <field name="name">Planning</field>
+            <field name="res_model">construction.planning</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <menuitem id="menu_construction_planning"
+            name="Planning"
+            parent="project.menu_main_pm"
+            action="action_construction_planning"
+            sequence="40"/>
+
+    </data>
+</odoo>

--- a/construction_management/views/project_views.xml
+++ b/construction_management/views/project_views.xml
@@ -17,6 +17,15 @@
                     <page string="Milestones">
                         <field name="milestone_ids"/>
                     </page>
+                    <page string="Planning">
+                        <field name="planning_ids"/>
+                    </page>
+                    <page string="Documents">
+                        <field name="document_ids"/>
+                    </page>
+                    <page string="Quality Control">
+                        <field name="quality_control_ids"/>
+                    </page>
                 </xpath>
             </field>
         </record>

--- a/construction_management/views/quality_control_views.xml
+++ b/construction_management/views/quality_control_views.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Quality Control views -->
+        <record id="view_construction_quality_control_tree" model="ir.ui.view">
+            <field name="name">construction.quality.control.tree</field>
+            <field name="model">construction.quality.control</field>
+            <field name="arch" type="xml">
+                <tree string="Quality Control">
+                    <field name="name"/>
+                    <field name="project_id"/>
+                    <field name="task_id"/>
+                    <field name="inspection_date"/>
+                    <field name="inspected_by"/>
+                    <field name="status"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_construction_quality_control_form" model="ir.ui.view">
+            <field name="name">construction.quality.control.form</field>
+            <field name="model">construction.quality.control</field>
+            <field name="arch" type="xml">
+                <form string="Quality Control">
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="project_id"/>
+                            <field name="task_id"/>
+                            <field name="inspection_date"/>
+                            <field name="inspected_by"/>
+                            <field name="status"/>
+                        </group>
+                        <notebook>
+                            <page string="Notes">
+                                <field name="notes"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_construction_quality_control" model="ir.actions.act_window">
+            <field name="name">Quality Control</field>
+            <field name="res_model">construction.quality.control</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <menuitem id="menu_construction_quality_control"
+            name="Quality Control"
+            parent="project.menu_main_pm"
+            action="action_construction_quality_control"
+            sequence="60"/>
+
+    </data>
+</odoo>


### PR DESCRIPTION
This commit consolidates the document management functionality into a single model and view.

The redundant `Document` and `Drawing` models have been removed from `document_management.py`, and the `document_management_views.xml` has been updated to use the `construction.document` model. The redundant `document_views.xml` file has been deleted.