### PR TITLE
feat(barcode): Add client-specific product barcodes

### DIFF
--- a/qx_client_barcode/__init__.py
+++ b/qx_client_barcode/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/qx_client_barcode/__manifest__.py
+++ b/qx_client_barcode/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Client Specific Product Barcode',
+    'version': '14.0.1.0.0',
+    'summary': 'Enable client-specific product barcodes using the pricelist',
+    'description': """
+        This module allows setting a specific barcode for a product on a client's pricelist.
+        This barcode is then displayed on Sales Orders and Delivery Slips.
+    """,
+    'author': 'Qx',
+    'website': '',
+    'category': 'Sales',
+    'depends': ['sale_management', 'stock'],
+    'data': [
+        'views/product_pricelist_item_views.xml',
+        'views/sale_order_views.xml',
+        'views/stock_move_views.xml',
+        'views/report_deliveryslip.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/qx_client_barcode/models/__init__.py
+++ b/qx_client_barcode/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_pricelist_item
+from . import sale_order_line
+from . import stock_move

--- a/qx_client_barcode/models/product_pricelist_item.py
+++ b/qx_client_barcode/models/product_pricelist_item.py
@@ -1,0 +1,6 @@
+from odoo import models, fields
+
+class ProductPricelistItem(models.Model):
+    _inherit = 'product.pricelist.item'
+
+    client_barcode = fields.Char('Client Barcode')

--- a/qx_client_barcode/models/sale_order_line.py
+++ b/qx_client_barcode/models/sale_order_line.py
@@ -1,0 +1,31 @@
+from odoo import models, fields, api
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    client_barcode = fields.Char(
+        'Client Barcode',
+        compute='_compute_client_barcode',
+        store=True
+    )
+
+    @api.depends('product_id', 'order_id.pricelist_id')
+    def _compute_client_barcode(self):
+        for line in self:
+            # Default to product barcode
+            line.client_barcode = line.product_id.barcode or ''
+            if line.product_id and line.order_id.pricelist_id:
+                # Search for a specific client barcode on the pricelist
+                # The search is ordered to prioritize the rule on the variant over the template
+                pricelist_item = self.env['product.pricelist.item'].search([
+                    ('pricelist_id', '=', line.order_id.pricelist_id.id),
+                    ('product_tmpl_id', '=', line.product_id.product_tmpl_id.id),
+                    '|',
+                    ('product_id', '=', line.product_id.id),
+                    ('product_id', '=', False),
+                    ('client_barcode', '!=', False),
+                    ('client_barcode', '!=', '')
+                ], order='product_id desc', limit=1)
+
+                if pricelist_item:
+                    line.client_barcode = pricelist_item.client_barcode

--- a/qx_client_barcode/models/stock_move.py
+++ b/qx_client_barcode/models/stock_move.py
@@ -1,0 +1,40 @@
+from odoo import models, fields, api
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    client_barcode = fields.Char(
+        'Client Barcode',
+        compute='_compute_client_barcode',
+        store=True
+    )
+
+    @api.depends('product_id', 'picking_id.partner_id', 'sale_line_id.client_barcode')
+    def _compute_client_barcode(self):
+        for move in self:
+            # Default to product barcode
+            barcode = move.product_id.barcode or ''
+
+            # If linked to a sale order line, just copy its client barcode
+            if move.sale_line_id and move.sale_line_id.client_barcode:
+                barcode = move.sale_line_id.client_barcode
+            # If not from a sale order, try to find from partner's pricelist
+            elif move.product_id and move.picking_id.partner_id:
+                partner = move.picking_id.partner_id
+                if partner.property_product_pricelist:
+                    pricelist = partner.property_product_pricelist
+
+                    pricelist_item = self.env['product.pricelist.item'].search([
+                        ('pricelist_id', '=', pricelist.id),
+                        ('product_tmpl_id', '=', move.product_id.product_tmpl_id.id),
+                        '|',
+                        ('product_id', '=', move.product_id.id),
+                        ('product_id', '=', False),
+                        ('client_barcode', '!=', False),
+                        ('client_barcode', '!=', '')
+                    ], order='product_id desc', limit=1)
+
+                    if pricelist_item:
+                        barcode = pricelist_item.client_barcode
+
+            move.client_barcode = barcode

--- a/qx_client_barcode/views/product_pricelist_item_views.xml
+++ b/qx_client_barcode/views/product_pricelist_item_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_pricelist_item_view_form_inherit_client_barcode" model="ir.ui.view">
+        <field name="name">product.pricelist.item.form.inherit.client.barcode</field>
+        <field name="model">product.pricelist.item</field>
+        <field name="inherit_id" ref="product.product_pricelist_item_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='price']" position="after">
+                <field name="client_barcode"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/qx_client_barcode/views/report_deliveryslip.xml
+++ b/qx_client_barcode/views/report_deliveryslip.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_delivery_document_inherit_client_barcode" inherit_id="stock.report_delivery_document">
+        <!-- Case 1: Detailed Operations (stock.move.line) -->
+        <xpath expr="//table[hasclass('table-sm')]//t[@t-foreach='o.move_line_ids_without_package']//span[@t-field='move_line.product_id']/.." position="inside">
+            <br/>
+            <t t-if="move_line.move_id.client_barcode">
+                <barcode t-att-code="move_line.move_id.client_barcode" type="Code128" width="600" height="100"/>
+            </t>
+        </xpath>
+
+        <!-- Case 2: Move Lines (stock.move) -->
+        <xpath expr="//table[hasclass('table-sm')]//t[@t-foreach='o.move_lines']//span[@t-field='move.product_id']/.." position="inside">
+            <br/>
+            <t t-if="move.client_barcode">
+                <barcode t-att-code="move.client_barcode" type="Code128" width="600" height="100"/>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/qx_client_barcode/views/sale_order_views.xml
+++ b/qx_client_barcode/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit_client_barcode" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.client.barcode</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree/field[@name='product_id']" position="after">
+                <field name="client_barcode"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/qx_client_barcode/views/stock_move_views.xml
+++ b/qx_client_barcode/views/stock_move_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_form_inherit_client_barcode_move" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.client.barcode.move</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='move_lines']/tree/field[@name='product_id']" position="after">
+                <field name="client_barcode"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit introduces a new Odoo module `qx_client_barcode` that allows setting client-specific barcodes for products using pricelists.

Key features:
- Adds a `client_barcode` field to `product.pricelist.item`.
- Extends `sale.order.line` with a computed `client_barcode` field that falls back to the default product barcode.
- Extends `stock.move` with a similar computed `client_barcode` field.
- Modifies the Delivery Slip report to display the client-specific barcode using Code128.